### PR TITLE
Inspect request vars

### DIFF
--- a/lib/airbrake.js
+++ b/lib/airbrake.js
@@ -7,7 +7,6 @@ var util = require('util');
 var request = require('request');
 var xmlbuilder = require('xmlbuilder');
 var stackTrace = require('stack-trace');
-var traverse = require('traverse');
 var hashish = require('hashish');
 var querystring = require('querystring');
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "request": "1.9.8",
     "xmlbuilder": "https://github.com/felixge/xmlbuilder-js/tarball/4303eb2650a4b819a980b1dc9d2965862a1e9faf",
     "stack-trace": "0.0.5",
-    "traverse": "0.4.4",
     "hashish": "0.0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
I've replaced `traverse` with the built-in `util.inspect` in `airbrake.addRequestVars`. The built-in method takes care of circular references and handles `undefined` properties gracefully.

At the same time `inspect` also adds indentation to the output for readability. I'm not sure wether this is a feature or an issue in this case. Anyhow, `inspect` can receive arguments which [configure its behavior](http://nodejs.org/docs/latest/api/all.html#util.inspect) (not the indentation though).
