### PR TITLE
Update request and xmlbuilder dependencies to current latest versions

### DIFF
--- a/lib/airbrake.js
+++ b/lib/airbrake.js
@@ -123,7 +123,8 @@ Airbrake.prototype.url = function(path) {
 };
 
 Airbrake.prototype.notifyXml = function(err, pretty) {
-  var notice = xmlbuilder.create().begin('notice', {
+  var notice = xmlbuilder.create()
+  notice = notice.begin('notice', {
     version: '1.0',
     encoding: 'UTF-8'
   });
@@ -133,7 +134,7 @@ Airbrake.prototype.notifyXml = function(err, pretty) {
   this.appendRequestXml(notice, err);
   this.appendServerEnvironmentXml(notice);
 
-  return notice.up().toString({pretty: pretty});
+  return notice.doc().toString({pretty: pretty});
 };
 
 Airbrake.prototype.appendHeaderXml = function(notice) {
@@ -153,6 +154,7 @@ Airbrake.prototype.appendHeaderXml = function(notice) {
         .txt(Airbrake.PACKAGE.homepage)
       .up()
     .up();
+    console.log(notice.toString({pretty: true}))
 };
 
 Airbrake.prototype.appendErrorXml = function(notice, err) {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "request": "2.2.9",
-    "xmlbuilder": "0.1.5",
+    "xmlbuilder": "0.3.1",
     "stack-trace": "0.0.5",
     "hashish": "0.0.4"
   },


### PR DESCRIPTION
Utilize the latest version of the request and xmlbuilder modules.  This fixes the dependency warning from their package.json files.

```
 npm WARN request@1.9.8 package.json: bugs['web'] should probably be bugs['url']
 npm WARN xmlbuilder@0.1.5 package.json: bugs['web'] should probably be bugs['url']
```

All tests are passing.
