### PR TITLE
Respect http_proxy environment variable, if set

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -64,6 +64,7 @@ This screenshot shows an airbrake error send from this module:
 * Optional auto-handler for `uncaughtException` events
 * Provides notification url linking to airbrake in `notify()` callback
 * Timeout airbrake requests after 30 seconds, you never know
+* Respect `http_proxy` (or `https_proxy` if `airbrake.protocol` is https) environment variable
 
 [long-stack-traces]: https://github.com/tlrobinson/long-stack-traces
 
@@ -221,6 +222,11 @@ options:
 * `user:` The user doing the deployment, defaults to `process.env.USER`.
 * `repo:` The github url of this repository. Defaults to `''`.
 * `rev:` The revision of this deployment. Defaults to `''`.
+
+## Proxy support
+
+If the environment variable `http_proxy` (or `https_proxy` if `airbrake.protocol` is
+https) is set, a proxy will be used for posting to the airbrake host.
 
 ## Alternative modules
 

--- a/lib/airbrake.js
+++ b/lib/airbrake.js
@@ -109,6 +109,7 @@ Airbrake.prototype.notify = function(err, cb) {
       'Content-Length': body.length,
       'Content-Type': 'text/xml',
     },
+    proxy: this.protocol == 'http' ? process.env.http_proxy : process.env.https_proxy,
   };
 
   request(options, function(err, res, body) {


### PR DESCRIPTION
This will allow calling out to airbrake from inside networks protected by an outbound proxy.

fixes felixge/node-airbrake#21
