### PR TITLE
Make development and test default dev environments

### DIFF
--- a/lib/airbrake.js
+++ b/lib/airbrake.js
@@ -20,7 +20,7 @@ function Airbrake() {
   this.projectRoot = null;
   this.appVersion = null;
   this.timeout = 30 * 1000;
-  this.developmentEnvironments = [];
+  this.developmentEnvironments = ['development', 'test'];
 
   this.protocol = 'http';
   this.serviceHost = 'api.airbrake.io';


### PR DESCRIPTION
It's uncommon to want exceptions to go to Airbrake's servers in development mode and during test runs.

This implements some better defaults as discussed in #14. I tried to run the suite with these changes but Airbrake loves to rate limit, and I was getting 503s before the suite completed.
