### PR TITLE
Add accept header for compatiblity with errbit.

### DIFF
--- a/lib/airbrake.js
+++ b/lib/airbrake.js
@@ -108,6 +108,7 @@ Airbrake.prototype.notify = function(err, cb) {
     headers: {
       'Content-Length': body.length,
       'Content-Type': 'text/xml',
+      'Accept': 'text/xml',
     },
   };
 


### PR DESCRIPTION
Errbit responds with 406 Not Acceptable if the Accept header isn't provided.

Didn't originally send this because I saw pull request https://github.com/felixge/node-airbrake/pull/9, but it has been accidentally closed, the author of the pull request has deleted his fork and the author wasn't responding to feedback.

We have been using this in production for over a year now using `"airbrake": "https://github.com/dylanahsmith/node-airbrake/tarball/e1704a79ff3d33dcb0cb6d6776c4690a240f67dc",` in the package.json dependencies hash.
