### PR TITLE
if AIRBRAKE_SERVER env varibale is set, use that.

### DIFF
--- a/lib/airbrake.js
+++ b/lib/airbrake.js
@@ -23,7 +23,7 @@ function Airbrake() {
   this.developmentEnvironments = ['development', 'test'];
 
   this.protocol = 'http';
-  this.serviceHost = 'api.airbrake.io';
+  this.serviceHost =  process.env.AIRBRAKE_SERVER || 'api.airbrake.io';
 }
 
 Airbrake.PACKAGE = (function() {


### PR DESCRIPTION
This allows use of private hosted errbit.
