### PR TITLE
Fixed crash when http request returns undefined body but no error object

### DIFF
--- a/lib/airbrake.js
+++ b/lib/airbrake.js
@@ -118,7 +118,7 @@ Airbrake.prototype.notify = function(err, cb) {
     }
 
     if (undefined === body) {
-      return callback(new Error('invalid body'))
+      return callback(new Error('invalid body'));
     }
 
     if (res.statusCode >= 300) {


### PR DESCRIPTION
Hi,

I saw a few crashes in my Node.js app that were caused by the Airbrake library. 

They were being caused by request() sometimes returning an undefined body but no error message.

This is the simplest fix I could come up with.

Cheers,
Carlos
