### PR TITLE
Remove the project root in stack traces to make direct Github links work

### DIFF
--- a/lib/airbrake.js
+++ b/lib/airbrake.js
@@ -215,11 +215,13 @@ Airbrake.prototype.appendErrorXml = function(notice, err) {
       .up()
       .ele('backtrace');
 
+  var self = this;
+
   trace.forEach(function(callSite) {
     error
       .ele('line')
         .att('method', callSite.getFunctionName() || '')
-        .att('file', callSite.getFileName() || '')
+        .att('file', (callSite.getFileName() || '').replace(self.projectRoot, ""))
         .att('number', callSite.getLineNumber() || '');
   });
 };


### PR DESCRIPTION
This change makes it possible to click the direct links to the github file on airbrake.

The project root should not necessarily be contained in the stack trace.
