### PR TITLE
Make notifyXml return a Buffer object

### DIFF
--- a/lib/airbrake.js
+++ b/lib/airbrake.js
@@ -181,7 +181,7 @@ Airbrake.prototype.notifyXml = function(err, pretty) {
   this.appendRequestXml(notice, err);
   this.appendServerEnvironmentXml(notice);
 
-  return notice.doc().toString({pretty: pretty});
+  return new Buffer(notice.doc().toString({pretty: pretty}));
 };
 
 Airbrake.prototype.appendHeaderXml = function(notice) {


### PR DESCRIPTION
If (for example) request.body contains non-ascii characters, this caused the http request to not send the correct `Content-Length` header, which in turn causes errbit to not read the entire document.

I changed `Airbrake.prototype.notifyXml` so that it returns a `Buffer` object, which will report a proper length when asked for it in `Airbarke.prototype.notify`.