### PR TITLE
Add custom user-agent support

### DIFF
--- a/lib/airbrake.js
+++ b/lib/airbrake.js
@@ -279,6 +279,10 @@ Airbrake.prototype.cgiDataVars = function(err) {
     cgiData[key] = process.env[key];
   });
 
+  if (err.ua) {
+    cgiData.HTTP_USER_AGENT = err.ua;
+  }
+
   var exclude = [
     'type',
     'message',
@@ -289,6 +293,7 @@ Airbrake.prototype.cgiDataVars = function(err) {
     'params',
     'component',
     'action',
+    'ua',
   ];
 
   Object.keys(err).forEach(function(key) {

--- a/lib/airbrake.js
+++ b/lib/airbrake.js
@@ -217,13 +217,35 @@ Airbrake.prototype.appendErrorXml = function(notice, err) {
 
   var self = this;
 
-  trace.forEach(function(callSite) {
-    error
+  if (trace.length) {
+    trace.forEach(function(callSite) {
+      error
       .ele('line')
-        .att('method', callSite.getFunctionName() || '')
-        .att('file', (callSite.getFileName() || '').replace(self.projectRoot, ""))
-        .att('number', callSite.getLineNumber() || '');
-  });
+      .att('method', callSite.getFunctionName() || '')
+      .att('file', (callSite.getFileName() || '').replace(self.projectRoot, ""))
+      .att('number', callSite.getLineNumber() || '');
+    });
+  } else if (err.stack) {
+    err.stack.split('\n').forEach(function(line) {
+      var m = line.match(/(.*)\((.*):(\d+):\d+\)/);
+      if (m) {
+        var method = m[1].trim();
+        var file = m[2].replace(self.projectRoot, "");
+        var number = m[3];
+        error
+        .ele('line')
+        .att('method', method)
+        .att('file', file)
+        .att('number', number);
+      } else {
+        error
+        .ele('line')
+        .att('method', line.trim())
+        .att('file', '')
+        .att('number', '');
+      }
+    });
+  }
 };
 
 Airbrake.prototype.appendRequestXml = function(notice, err) {
@@ -296,13 +318,15 @@ Airbrake.prototype.cgiDataVars = function(err) {
     'ua',
   ];
 
-  Object.keys(err).forEach(function(key) {
-    if (exclude.indexOf(key) >= 0) {
-      return;
-    }
+  if (typeof err === 'object') {
+    Object.keys(err).forEach(function(key) {
+      if (exclude.indexOf(key) >= 0) {
+        return;
+      }
 
-    cgiData['err.' + key] = err[key];
-  });
+      cgiData['err.' + key] = err[key];
+    });
+  }
 
   cgiData['process.pid'] = process.pid;
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test": "test/run.js"
   },
   "dependencies": {
-    "request": "~2.21.0",
+    "request": "~2.40.0",
     "xmlbuilder": "~0.4.2",
     "stack-trace": "~0.0.6",
     "hashish": "~0.0.4"


### PR DESCRIPTION
For now, __Airbrake.prototype.cgiDataVars__ adds prefix '__err.__' to all custom properties, so it's impossible to add __HTTP_USER_AGENT__ property from Error.
Here is some workarounds.