### PR TITLE
Fix getter of params and session variables.

### DIFF
--- a/lib/airbrake.js
+++ b/lib/airbrake.js
@@ -319,13 +319,13 @@ Airbrake.prototype.cgiDataVars = function(err) {
 };
 
 Airbrake.prototype.sessionVars = function(err) {
-  return (err.session instanceof Object)
+  return (typeof err.session  === 'object')
     ? err.session
     : {};
 };
 
 Airbrake.prototype.paramsVars = function(err) {
-  return (err.params instanceof Object)
+  return (typeof err.params === 'object')
     ? err.params
     : {};
 };


### PR DESCRIPTION
Hello there.
First thanks for this lib. Another one time-saver.

For me params works only with this fix. `typeof err.params  === 'object'`

Chrome 30.0.1599.66. OSX.

Tried all. Here is how i set it. Tried to set it in loop, because this bug ($route.current.params already object).
```coffee
err.params = new Object()
_.each $route.current.params, (v, k) ->
  err.params[k] = v
```
This is my example params object:
```js
{
  "nodeId": "mrcr4.ru",
  "organizationId": "somename"
}
```
