### PR TITLE
NodeJS domain in error object and circular structures

### DIFF
--- a/lib/airbrake.js
+++ b/lib/airbrake.js
@@ -9,6 +9,7 @@ var xmlbuilder = require('xmlbuilder');
 var stackTrace = require('stack-trace');
 var hashish = require('hashish');
 var querystring = require('querystring');
+var stringify = require('json-stringify-safe');
 
 module.exports = Airbrake;
 util.inherits(Airbrake, EventEmitter);
@@ -261,7 +262,7 @@ Airbrake.prototype.addRequestVars = function(request, type, vars) {
 
     value = vars[key];
     if ('string' !== typeof value) {
-      value = util.inspect(value, { showHidden: true, depth: null });
+      value = stringify(value);
     }
 
     value = value.replace(/[\u0000-\u0008\u000B-\u000C\u000E-\u001F\uD800-\uDFFF\uFFFE-\uFFFF]/g, " ");
@@ -289,6 +290,9 @@ Airbrake.prototype.cgiDataVars = function(err) {
     'params',
     'component',
     'action',
+	'domain',
+	'domainEmitter',
+	'domainBound'
   ];
 
   Object.keys(err).forEach(function(key) {

--- a/package.json
+++ b/package.json
@@ -31,10 +31,11 @@
     "test": "test/run.js"
   },
   "dependencies": {
+    "hashish": "~0.0.4",
+    "json-stringify-safe": "~5.0.0",
     "request": "~2.40.0",
-    "xmlbuilder": "~0.4.2",
     "stack-trace": "~0.0.6",
-    "hashish": "~0.0.4"
+    "xmlbuilder": "~0.4.2"
   },
   "devDependencies": {
     "sinon": "~1.7.2",


### PR DESCRIPTION
We start using error domain feature in NodeJS - http://nodejs.org/api/domain.html and get an issue. node-airbake tried to util.inspect err.domain which has circular structures and hang entire app for several minutes. There are two issues:
- It is not safe to use util.inspect without limiting depth or detecting circular references
- err.domain and few more related variables are useless for error reporting