### PR TITLE
Remove documentation for airbrake.hostname which was removed.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -91,7 +91,6 @@ each delivered error:
 * **server-environment.project-root:** (`airbrake.projectRoot` string if set)
 * **server-environment.environment-name:** (`airbrake.env` string)
 * **server-environment.app-version:** (`airbrake.appVersion string if set)
-* **server-environment.hostname:** (`airbrake.hostname` string if set)
 
 You can add additional context information by modifying the error properties
 listed above:


### PR DESCRIPTION
## Problem

The Readme.md mentions

* **server-environment.hostname:** (`airbreak.hostname`, if set)

which isn't actually a supported setting.

That line was added by commit 906ad840261f24fdfd9560facd9da9f7b5f6c961 which is where support for that setting was added only in commented out code, with the explanation:

```
  // This is not documented, but the Airbrake API told me about it when sending
  // some invalid data. Going to find out if they want people to use it first
  // before enabling.
```

The [Airbrake Notifier V2 API](https://help.airbrake.io/kb/api-2/notifier-api-version-23) does appear to be missing for that XML field, which is probably why the commented out code was later removed for that XML field was later removed.

Note that the [airbrake ruby client sends this XML field](https://github.com/airbrake/airbrake/blob/b192f3dcff54f135c3702b8b10ad7384844139e9/lib/airbrake/notice.rb#L189).  That would indicate to me that they don't have a problem with the field being sent, so I think this should be supported in the future.

## Solution

Remove that line from the Readme to avoid confusing developers.