### PR TITLE
Add airbrake.expressHandler() documentation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -210,6 +210,14 @@ Registers a `process.on('uncaughtException')` listener. When an uncaught
 exception occurs, the error is send to airbrake, and then re-thrown to
 kill the process.
 
+### airbrake.expressHandler(disableUncaughtException)
+
+A custom error handler that is used with Express. Integrate with Express
+middleware using `app.use()`.
+
+Options:
+* `disableUncaughtException`: Disables re-throwing and killing process on uncaught exception.
+
 ### airbrake.notify(err, [cb])
 
 Sends the given `err` to airbrake.


### PR DESCRIPTION
This PR adds `airbrake.expressHandler()` to the API documentation. The reasoning behind adding this extra documentation is to document `expressHandler`'s option `disableUncaughtException`, which prevents your server from re-throwing/calling `process.exit(1)` when an error is detected.