### PR TITLE
Stop serializing environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### master
 
+### [v0.3.9][v0.3.9] (February 15, 2016)
+
 * start sending user agent info from Express handler ([#79][79])
 * make error handler's killing of process customizable ([#45][45])
 * return a Buffer object from `notifyXML` to fix Errbit incompatibility ([#51][51])
@@ -30,3 +32,4 @@
 [71]:https://github.com/airbrake/node-airbrake/pull/71
 [72]:https://github.com/airbrake/node-airbrake/pull/72
 [73]:https://github.com/airbrake/node-airbrake/pull/73
+[v0.3.9]: https://github.com/airbrake/node-airbrake/releases/tag/v0.3.9

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ define release
 		j.version = \"$$NEXT_VERSION\";\
 		var s = JSON.stringify(j, null, 2);\
 		require('fs').writeFileSync('./package.json', s);" && \
-	git commit -m "Version $$NEXT_VERSION" -- package.json && \
-	git tag "$$NEXT_VERSION" -m "Version $$NEXT_VERSION"
+	git commit -m "Release v$$NEXT_VERSION" -- package.json && \
+	git tag "v$$NEXT_VERSION" -m "Version $$NEXT_VERSION"
 endef
 
 release-patch: test

--- a/lib/airbrake.js
+++ b/lib/airbrake.js
@@ -316,10 +316,6 @@ Airbrake.prototype.addRequestVars = function(request, type, vars) {
 
 Airbrake.prototype.cgiDataVars = function(err) {
   var cgiData = {};
-  Object.keys(process.env).forEach(function(key) {
-    cgiData[key] = process.env[key];
-  });
-
   var self = this;
 
   if (err.ua){

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "name": "airbrake",
   "description": "Node.js client for airbrake.io",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "homepage": "https://github.com/airbrake/node-airbrake",
   "repository": {
     "type": "git",

--- a/test/fast/test-request-vars.js
+++ b/test/fast/test-request-vars.js
@@ -38,9 +38,6 @@ var os = require('os');
   delete cgiData['process.argv'];
   delete cgiData['os.loadavg'];
   delete cgiData['os.uptime'];
-
-  assert.deepEqual(cgiData, process.env);
-  assert.notStrictEqual(cgiData, process.env);
 })();
 
 (function testCustomErrorProperties() {


### PR DESCRIPTION
It's not safe to serialize all environment variables, since users may have sensitive data in there.