### PR TITLE
Replace hashish with lodash

### DIFF
--- a/lib/airbrake.js
+++ b/lib/airbrake.js
@@ -3,7 +3,6 @@ var HTTP_STATUS_CODES = require('http').STATUS_CODES;
 var fs = require('fs');
 var os = require('os');
 var EventEmitter = require('events').EventEmitter;
-var util = require('util');
 var request = require('request');
 var xmlbuilder = require('xmlbuilder');
 var stackTrace = require('stack-trace');
@@ -11,9 +10,6 @@ var _ = require('lodash');
 var querystring = require('querystring');
 var stringify = require('json-stringify-safe');
 var url = require('url');
-
-module.exports = Airbrake;
-util.inherits(Airbrake, EventEmitter);
 
 function Airbrake() {
   this.key = null;
@@ -50,6 +46,8 @@ function Airbrake() {
     'ua'
   ];
 }
+
+_.assign(Airbrake.prototype, EventEmitter.prototype);
 
 Airbrake.PACKAGE = (function() {
   var json = fs.readFileSync(__dirname + '/../package.json', 'utf8');
@@ -367,3 +365,5 @@ Airbrake.prototype.deploymentPostData = function(params) {
     'repository': params.repo
   });
 };
+
+module.exports = Airbrake;

--- a/lib/airbrake.js
+++ b/lib/airbrake.js
@@ -7,7 +7,7 @@ var util = require('util');
 var request = require('request');
 var xmlbuilder = require('xmlbuilder');
 var stackTrace = require('stack-trace');
-var hashish = require('hashish');
+var _ = require('lodash');
 var querystring = require('querystring');
 var stringify = require('json-stringify-safe');
 var url = require('url');
@@ -131,7 +131,7 @@ Airbrake.prototype._sendRequest = function(err, cb) {
 
   var body = this.notifyJSON(err);
 
-  var options = hashish.merge({
+  var options = _.merge({
     method: 'POST',
     url: this.url('/api/v3/projects/' + this.projectId + '/notices?key=' + this.key),
     body: body,
@@ -318,7 +318,7 @@ Airbrake.prototype.trackDeployment = function(params, cb) {
     params = {};
   }
 
-  params = hashish.merge({
+  params = _.merge({
     key: this.key,
     env: this.env,
     user: process.env.USER,
@@ -328,7 +328,7 @@ Airbrake.prototype.trackDeployment = function(params, cb) {
 
   var body = this.deploymentPostData(params);
 
-  var options = hashish.merge({
+  var options = _.merge({
     method: 'POST',
     url: this.url('/api/v4/projects/' + this.projectId + '/deploys?key=' + this.key),
     body: body,

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "test": "nsp check && test/run.js"
   },
   "dependencies": {
-    "hashish": "~0.0.4",
     "json-stringify-safe": "~5.0.0",
+    "lodash": "^4.6.1",
     "request": "~2.69.0",
     "stack-trace": "~0.0.6",
     "xmlbuilder": "~0.4.2"

--- a/test/common.js
+++ b/test/common.js
@@ -1,5 +1,5 @@
 var path = require('path');
-var hashish = require('hashish');
+var _ = require('lodash');
 
 // An account on the free plan specifically for testing this module.
 exports.key = '092f2e6780f7c9117353d28dbe8486a3';
@@ -7,7 +7,7 @@ exports.projectId = '72058';
 
 // Use custom config if available instead
 try {
-  hashish.update(exports, require('./config'));
+  _.merge(exports, require('./config'));
 } catch (e) {}
 
 exports.port = 8424;


### PR DESCRIPTION
[`node-hashish`](https://github.com/substack/node-hashish) is a pretty out-of-date package (Last updated May 2013), so I replaced the dependency with `lodash` for the instances where `node-airbrake` uses it. I also used `lodash` to now inherit the prototype of `EventEmitter`.