### PR TITLE
Add eslint-airbnb-config/legacy to project

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,15 @@
+{
+  "extends": "airbnb-base/legacy",
+  "rules": {
+    "no-console": 0,
+    "func-names": 0,
+    "vars-on-top": 0,
+    "no-underscore-dangle": ["error", {
+      "allow": [
+        '_onError',
+        '_callback',
+        '_sendRequest'
+      ]
+    }]
+  }
+}

--- a/lib/airbrake.js
+++ b/lib/airbrake.js
@@ -4,10 +4,8 @@ var fs = require('fs');
 var os = require('os');
 var EventEmitter = require('events').EventEmitter;
 var request = require('request');
-var xmlbuilder = require('xmlbuilder');
 var stackTrace = require('stack-trace');
 var _ = require('lodash');
-var querystring = require('querystring');
 var stringify = require('json-stringify-safe');
 var execSync = require('sync-exec');
 var url = require('url');
@@ -28,7 +26,7 @@ function Airbrake() {
 
   this.proxy = null;
   this.protocol = 'https';
-  this.serviceHost =  process.env.AIRBRAKE_SERVER || 'api.airbrake.io';
+  this.serviceHost = process.env.AIRBRAKE_SERVER || 'api.airbrake.io';
   this.requestOptions = {};
   this.ignoredExceptions = [];
   this.exclude = [
@@ -50,12 +48,12 @@ function Airbrake() {
 
 _.assign(Airbrake.prototype, EventEmitter.prototype);
 
-Airbrake.PACKAGE = (function() {
+Airbrake.PACKAGE = (function () {
   var json = fs.readFileSync(__dirname + '/../package.json', 'utf8');
   return JSON.parse(json);
-})();
+}());
 
-Airbrake.createClient = function(projectId, key, env) {
+Airbrake.createClient = function (projectId, key, env) {
   var instance = new this();
   instance.key = key;
   instance.env = env || instance.env;
@@ -63,46 +61,48 @@ Airbrake.createClient = function(projectId, key, env) {
   return instance;
 };
 
-Airbrake.prototype.expressHandler = function(disableUncaughtException) {
+Airbrake.prototype.expressHandler = function (disableUncaughtException) {
   var self = this;
 
-  if(!disableUncaughtException) {
-    process.on('uncaughtException', function(err) {
+  if (!disableUncaughtException) {
+    process.on('uncaughtException', function (err) {
       self._onError(err, true);
     });
   }
 
   return function errorHandler(err, req, res, next) {
-    if (res.statusCode < 400) res.statusCode = 500;
+    var error = err;
+    var requestObj = req;
+    var responseObj = res;
 
-    err.url = req.url;
-    err.component = req.url;
-    err.action = req.method;
-    err.params = req.body;
-    err.session = req.session;
-    err.ua = req.get('User-Agent');
+    if (responseObj.statusCode < 400) responseObj.statusCode = 500;
+
+    error.url = requestObj.url;
+    error.component = requestObj.url;
+    error.action = requestObj.method;
+    error.params = requestObj.body;
+    error.session = requestObj.session;
+    error.ua = requestObj.get('User-Agent');
 
     self._onError(err, false);
     next(err);
   };
 };
 
-Airbrake.prototype._onError = function(err, die) {
+Airbrake.prototype._onError = function (err, die) {
   var self = this;
-  if (!(err instanceof Error)) {
-    err = new Error(err);
-  }
+  var error = (err instanceof Error) ? err : new Error(err);
   self.log('Airbrake: Uncaught exception, sending notification for:');
-  self.log(err.stack || err);
+  self.log(error.stack || error);
 
-  self.notify(err, function(notifyErr, url, devMode) {
+  self.notify(error, function (notifyErr, notifyUrl, devMode) {
     if (notifyErr) {
       self.log('Airbrake: Could not notify service.');
       self.log(notifyErr.stack);
     } else if (devMode) {
       self.log('Airbrake: Dev mode, did not send.');
     } else {
-      self.log('Airbrake: Notified service: ' + url);
+      self.log('Airbrake: Notified service: ' + notifyUrl);
     }
 
     if (die) {
@@ -111,21 +111,21 @@ Airbrake.prototype._onError = function(err, die) {
   });
 };
 
-Airbrake.prototype.handleExceptions = function(die) {
+Airbrake.prototype.handleExceptions = function (die) {
   var self = this;
-  if (typeof die === 'undefined') {
-      die = true;
-  }
-  process.on('uncaughtException', function(err) {
-    self._onError(err, die);
+  var shouldDie = (typeof die === 'undefined') ? true : die;
+  process.on('uncaughtException', function (err) {
+    self._onError(err, shouldDie);
   });
 };
 
-Airbrake.prototype.log = function(str) {
-  if(this.consoleLogError) console.error(str);
+Airbrake.prototype.log = function (str) {
+  if (this.consoleLogError) {
+    console.error(str);
+  }
 };
 
-Airbrake.prototype._sendRequest = function(err, cb) {
+Airbrake.prototype._sendRequest = function (err, cb) {
   var callback = this._callback(cb);
 
   var body = this.notifyJSON(err);
@@ -138,61 +138,61 @@ Airbrake.prototype._sendRequest = function(err, cb) {
     headers: {
       'Content-Length': body.length,
       'Content-Type': 'application/json',
-      'Accept': 'application/json',
-    },
+      Accept: 'application/json'
+    }
   }, this.requestOptions);
 
-  request(options, function(err, res, body) {
-    if (err) {
+  request(options, function (requestErr, res, responseBody) {
+    if (requestErr) {
       return callback(err);
     }
 
-    if (undefined === body) {
+    if (typeof responseBody === 'undefined') {
       return callback(new Error('invalid body'));
     }
 
     if (res.statusCode >= 300) {
       var status = HTTP_STATUS_CODES[res.statusCode];
 
-      var explanation = body.match(/<error>([^<]+)/i);
+      var explanation = responseBody.match(/<error>([^<]+)/i);
       explanation = (explanation)
         ? ': ' + explanation[1]
-        : ': ' + body;
+        : ': ' + responseBody;
 
       return callback(new Error(
         'Notification failed: ' + res.statusCode + ' ' + status + explanation
       ));
     }
 
-    var url = JSON.parse(body).url;
-    callback(null, url);
+    return callback(null, JSON.parse(responseBody).url);
   });
-}
+};
 
-Airbrake.prototype.notify = function(err, cb) {
+Airbrake.prototype.notify = function (err, cb) {
   var callback = this._callback(cb);
   var exit = false;
   // log errors instead of posting to airbrake if a dev enviroment
-  if (this.developmentEnvironments.indexOf(this.env) != -1) {
+  if (this.developmentEnvironments.indexOf(this.env) !== -1) {
     this.log(err);
     return callback(null, null, true);
   }
-  this.ignoredExceptions.forEach(function(exception){
-    if (err instanceof exception){
+
+  this.ignoredExceptions.forEach(function (exception) {
+    if (err instanceof exception) {
       exit = true;
     }
-  })
+  });
 
-  if (exit){
+  if (exit) {
     return callback(null, null, false);
   }
 
   return this._sendRequest(err, callback);
 };
 
-Airbrake.prototype._callback = function(cb) {
+Airbrake.prototype._callback = function (cb) {
   var self = this;
-  return function(err) {
+  return function (err) {
     if (cb) {
       cb.apply(self, arguments);
       return;
@@ -204,37 +204,37 @@ Airbrake.prototype._callback = function(cb) {
   };
 };
 
-Airbrake.prototype.url = function(path) {
+Airbrake.prototype.url = function (path) {
   return this.protocol + '://' + this.serviceHost + path;
 };
 
-Airbrake.prototype.environmentJSON = function(err){
+Airbrake.prototype.environmentJSON = function (err) {
   var cgiData = {};
   var self = this;
 
   if (this.whiteListKeys.length > 0) {
-    Object.keys(process.env).forEach(function(key) {
+    Object.keys(process.env).forEach(function (key) {
       if (self.whiteListKeys.indexOf(key) > -1) {
         cgiData[key] = process.env[key];
       } else {
-        cgiData[key] = "[FILTERED]";
+        cgiData[key] = '[FILTERED]';
       }
-    })
+    });
   } else if (this.blackListKeys.length > 0) {
-    Object.keys(process.env).forEach(function(key) {
-      if (self.blackListKeys.indexOf(key) > -1 ) {
-        cgiData[key] = "[FILTERED]";
+    Object.keys(process.env).forEach(function (key) {
+      if (self.blackListKeys.indexOf(key) > -1) {
+        cgiData[key] = '[FILTERED]';
       } else {
         cgiData[key] = process.env[key];
       }
-    })
+    });
   }
 
-  if (err.ua){
+  if (err.ua) {
     cgiData.HTTP_USER_AGENT = err.ua;
   }
 
-  Object.keys(err).forEach(function(key) {
+  Object.keys(err).forEach(function (key) {
     if (self.exclude.indexOf(key) >= 0) {
       return;
     }
@@ -244,7 +244,7 @@ Airbrake.prototype.environmentJSON = function(err){
 
   cgiData['process.pid'] = process.pid;
 
-  if(os.platform() != "win32") {
+  if (os.platform() !== 'win32') {
     // this two properties are *NIX only
     cgiData['process.uid'] = process.getuid();
     cgiData['process.gid'] = process.getgid();
@@ -261,73 +261,80 @@ Airbrake.prototype.environmentJSON = function(err){
   return cgiData;
 };
 
-Airbrake.prototype.contextJSON = function(err){
+Airbrake.prototype.contextJSON = function (err) {
   var context = {};
-  context["notifier"] = {
+  context.notifier = {
     name: Airbrake.PACKAGE.name,
     version: Airbrake.PACKAGE.version,
     url: Airbrake.PACKAGE.homepage
   };
-  context["environment"] = this.env;
-  context["rootDirectory"] = this.projectRoot;
-  context["os"] = os.type();
-  context["hostname"] = os.hostname();
-  context["url"] = url.resolve(this.host, err.url || '');
+
+  context.environment = this.env;
+  context.rootDirectory = this.projectRoot;
+  context.os = os.type();
+  context.hostname = os.hostname();
+  context.url = url.resolve(this.host, err.url || '');
   return context;
 };
 
-Airbrake.prototype.notifyJSON = function(err){
+Airbrake.prototype.notifyJSON = function (err) {
   var trace = stackTrace.parse(err);
   var self = this;
+
   return stringify({
-    "errors": [
+    errors: [
       {
-        type: err.type || "Error",
+        type: err.type || 'Error',
         message: err.message,
-        backtrace: trace.map(function(callSite){
+        backtrace: trace.map(function (callSite) {
           return {
-            "file": callSite.getFileName() || "",
-            "line": callSite.getLineNumber(),
-            "function": callSite.getFunctionName() || ""
+            file: callSite.getFileName() || '',
+            line: callSite.getLineNumber(),
+            function: callSite.getFunctionName() || ''
           };
-        }),
+        })
       }],
-      environment: this.environmentJSON(err),
-      context: this.contextJSON(err),
-      session: this.sessionVars(err),
-      params: this.paramsVars(err)
+    environment: self.environmentJSON(err),
+    context: self.contextJSON(err),
+    session: self.sessionVars(err),
+    params: self.paramsVars(err)
   });
 };
 
-Airbrake.prototype.sessionVars = function(err) {
-  return (typeof err.session  === 'object')
+Airbrake.prototype.sessionVars = function (err) {
+  return (typeof err.session === 'object')
     ? err.session
     : {};
 };
 
-Airbrake.prototype.paramsVars = function(err) {
+Airbrake.prototype.paramsVars = function (err) {
   return (typeof err.params === 'object')
     ? err.params
     : {};
 };
 
-Airbrake.prototype.trackDeployment = function(params, cb) {
-  if (typeof params === 'function') {
-    cb = params;
-    params = {};
-  }
-  params = params || {};
+Airbrake.prototype.trackDeployment = function (params, cb) {
+  var callback = cb;
+  var deploymentParams = params || {};
 
-  params = _.merge({
+  if (typeof deploymentParams === 'function') {
+    callback = deploymentParams;
+    deploymentParams = {};
+  }
+
+  var getCommandValue = function (command) {
+    return command.stdout.toString().slice(0, -1);
+  };
+
+  deploymentParams = _.merge({
     key: this.key,
     env: this.env,
     user: process.env.USER,
-    rev: execSync('git rev-parse HEAD').stdout.toString().slice(0, -1),
-    repo: execSync('git config --get remote.origin.url').stdout.
-      toString().slice(0, -1),
-  }, params);
+    rev: getCommandValue(execSync('git rev-parse HEAD')),
+    repo: getCommandValue(execSync('git config --get remote.origin.url'))
+  }, deploymentParams);
 
-  var body = this.deploymentPostData(params);
+  var body = this.deploymentPostData(deploymentParams);
 
   var options = _.merge({
     method: 'POST',
@@ -336,36 +343,36 @@ Airbrake.prototype.trackDeployment = function(params, cb) {
     timeout: this.timeout,
     headers: {
       'Content-Length': body.length,
-      'Content-Type': 'application/json',
+      'Content-Type': 'application/json'
     },
     proxy: this.proxy
   }, this.requestOptions);
 
-  var callback = this._callback(cb);
+  var requestCallback = this._callback(callback);
 
-  request(options, function(err, res, body) {
+  request(options, function (err, res, responseBody) {
     if (err) {
-      return callback(err);
+      return requestCallback(err);
     }
 
     if (res.statusCode >= 300) {
       var status = HTTP_STATUS_CODES[res.statusCode];
-      return callback(new Error(
-        'Deployment failed: ' + res.statusCode + ' ' + status + ': ' + body
+      return requestCallback(new Error(
+        'Deployment failed: ' + res.statusCode + ' ' + status + ': ' + responseBody
       ));
     }
 
-    callback(null, params);
+    return requestCallback(null, deploymentParams);
   });
 };
 
-Airbrake.prototype.deploymentPostData = function(params) {
+Airbrake.prototype.deploymentPostData = function (params) {
   return JSON.stringify({
-    'version': 'v2.0',
-    'environment': params.env,
-    'username': params.user,
-    'revision': params.rev,
-    'repository': params.repo
+    version: 'v2.0',
+    environment: params.env,
+    username: params.user,
+    revision: params.rev,
+    repository: params.repo
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -28,22 +28,25 @@
     "node": "*"
   },
   "scripts": {
-    "test": "nsp check && test/run.js"
+    "lint": "eslint .",
+    "test": "nsp check && test/run.js",
+    "posttest": "npm run lint"
   },
   "dependencies": {
     "json-stringify-safe": "~5.0.0",
     "lodash": "^4.6.1",
     "request": "~2.69.0",
     "stack-trace": "~0.0.6",
-    "sync-exec": "^0.6.2",
-    "xmlbuilder": "~0.4.2"
+    "sync-exec": "^0.6.2"
   },
   "devDependencies": {
+    "eslint": "~2.8.0",
+    "eslint-config-airbnb-base": "~1.0.3",
+    "eslint-plugin-import": "~1.5.0",
     "express": "~4.13.4",
     "far": "~0.0.4",
     "mockery": "~1.4.0",
     "nsp": "~2.2.0",
-    "semver": "*",
     "sinon": "~1.7.2"
   },
   "optionalDependencies": {},

--- a/test/common.js
+++ b/test/common.js
@@ -1,3 +1,7 @@
+// Ignore rules for initialization file.
+/* eslint global-require: 0 */
+/* eslint import/no-unresolved: 0 */
+
 var path = require('path');
 var _ = require('lodash');
 
@@ -8,12 +12,12 @@ exports.projectId = '122374';
 // Use custom config if available instead
 try {
   _.merge(exports, require('./config'));
-} catch (e) {}
+} catch (e) { console.log(e); }
 
 exports.port = 8424;
 
 var root = path.join(__dirname, '..');
 exports.dir = {
   root: root,
-  lib: root + '/lib',
+  lib: root + '/lib'
 };

--- a/test/fast/test-environment.js
+++ b/test/fast/test-environment.js
@@ -2,8 +2,10 @@ var common = require('../common');
 var assert = require('assert');
 var sinon = require('sinon');
 
+var Airbrake = require(common.dir.root);
+
 (function testAddingKeyToDevelopmentEnvironments() {
-  var airbrake = require(common.dir.root).createClient(null, common.key, 'dev');
+  var airbrake = Airbrake.createClient(null, common.key, 'dev');
   airbrake.developmentEnvironments.push('dev');
   sinon.stub(airbrake, '_sendRequest');
 
@@ -11,10 +13,10 @@ var sinon = require('sinon');
 
   assert.ok(!airbrake._sendRequest.called);
   airbrake._sendRequest.restore();
-})();
+}());
 
 (function testDevelopmentEnviroment() {
-  var airbrake = require(common.dir.root).createClient(null, common.key, 'dev');
+  var airbrake = Airbrake.createClient(null, common.key, 'dev');
   sinon.stub(airbrake, '_sendRequest');
 
   // this should be posted to airbrake simply because we didn't add 'dev' to
@@ -23,14 +25,14 @@ var sinon = require('sinon');
 
   assert.ok(airbrake._sendRequest.called);
   airbrake._sendRequest.restore();
-})();
+}());
 
 (function testProductionEnviroment() {
-  var airbrake = require(common.dir.root).createClient(null, common.key, 'production');
+  var airbrake = Airbrake.createClient(null, common.key, 'production');
   sinon.stub(airbrake, '_sendRequest');
 
   airbrake.notify(new Error('this should be posted to airbrake'));
 
   assert.ok(airbrake._sendRequest.called);
   airbrake._sendRequest.restore();
-})();
+}());

--- a/test/fast/test-express-handler.js
+++ b/test/fast/test-express-handler.js
@@ -10,12 +10,12 @@ sinon.spy(airbrake, '_onError');
 
 app.listen(common.port);
 
-app.get('/caught', function(req, res, next) {
+app.get('/caught', function (req, res, next) {
   var err = new Error('i am caught!');
   next(err);
 });
 
-app.get('/uncaught', function(req, res, next) {
+app.get('/uncaught', function () {
   // This actually gets handled by app.error() as well, express will catch
   // this one for us.
   var err = new Error('i am quasi uncaught!');
@@ -24,13 +24,20 @@ app.get('/uncaught', function(req, res, next) {
 
 app.use(airbrake.expressHandler());
 
-http.request({port: common.port, path: '/caught', headers: {
-    "User-Agent": "foo"
-  }}, function() {
-    assert.equal(airbrake._onError.getCall(0).args[0].ua, 'foo')
-    assert.equal(airbrake._onError.callCount, 1);
-    http.request({port: common.port, path: '/uncaught'}, function () {
-      assert.equal(airbrake._onError.callCount, 2);
-      process.exit()
-    }).end();
+http.request({
+  port: common.port,
+  path: '/caught',
+  headers: {
+    'User-Agent': 'foo'
+  }
+}, function () {
+  assert.equal(airbrake._onError.getCall(0).args[0].ua, 'foo');
+  assert.equal(airbrake._onError.callCount, 1);
+  http.request({
+    port: common.port,
+    path: '/uncaught'
+  }, function () {
+    assert.equal(airbrake._onError.callCount, 2);
+    process.exit();
+  }).end();
 }).end();

--- a/test/fast/test-handle-exceptions.js
+++ b/test/fast/test-handle-exceptions.js
@@ -39,7 +39,7 @@ var sinon = require('sinon');
 
     process.exit.restore();
     airbrake.log.restore();
-  })();
+  }());
 
   (function testNotifyError() {
     sinon.stub(airbrake, 'log');
@@ -53,12 +53,12 @@ var sinon = require('sinon');
     assert.ok(process.exit.calledWith(1));
 
     process.exit.restore();
-  })();
+  }());
 
   airbrake.log.restore();
   airbrake.notify.restore();
   process.on.restore();
-})();
+}());
 
 (function testDoNotKillProcessAfterUnhandledException() {
   sinon.stub(process, 'on');
@@ -79,4 +79,4 @@ var sinon = require('sinon');
   airbrake.log.restore();
   airbrake.notify.restore();
   process.on.restore();
-})();
+}());

--- a/test/fast/test-host.js
+++ b/test/fast/test-host.js
@@ -1,32 +1,30 @@
 var common = require('../common');
-var airbrake = require(common.dir.root).createClient()
+var airbrake = require(common.dir.root).createClient();
 var assert = require('assert');
-var sinon = require('sinon');
 var os = require('os');
-var xmlbuilder = require('xmlbuilder');
 
 (function testDefaultHost() {
   assert.equal(airbrake.host, 'https://' + os.hostname());
-})();
+}());
 
 (function testPlainHost() {
   var err = new Error('oh no');
-  var url = airbrake.contextJSON(err)["url"];
-  assert.equal(url, airbrake.host.toLowerCase() + "/");
-})();
+  var url = airbrake.contextJSON(err).url;
+  assert.equal(url, airbrake.host.toLowerCase() + '/');
+}());
 
 (function testPartialErrUrl() {
   var err = new Error('oh no');
   err.url = '/foo';
-  var url = airbrake.contextJSON(err)["url"];
+  var url = airbrake.contextJSON(err).url;
 
   assert.equal(url, airbrake.host.toLowerCase() + err.url);
-})();
+}());
 
 (function testAbsoluteErrUrl() {
   var err = new Error('oh no');
   err.url = 'http://example.org/bar';
-  var url = airbrake.contextJSON(err)["url"];
+  var url = airbrake.contextJSON(err).url;
 
   assert.equal(url, err.url);
-})();
+}());

--- a/test/fast/test-ignored-exceptions.js
+++ b/test/fast/test-ignored-exceptions.js
@@ -1,13 +1,15 @@
 var common = require('../common');
 var assert = require('assert');
 var sinon = require('sinon');
+var Airbrake = require(common.dir.root);
 
-function MyError(){
+function MyError() {
   var temp = Error.apply(this, arguments);
   temp.name = this.name = 'MyError';
   this.stack = temp.stack;
-  this.message = temp.message
+  this.message = temp.message;
 }
+
 MyError.prototype = Object.create(Error.prototype, {
   constructor: {
     value: MyError
@@ -15,7 +17,7 @@ MyError.prototype = Object.create(Error.prototype, {
 });
 
 (function testAddingExceptionToIgnoredExceptions() {
-  var airbrake = require(common.dir.root).createClient(null, common.key, 'production');
+  var airbrake = Airbrake.createClient(null, common.key, 'production');
   airbrake.ignoredExceptions.push(MyError);
 
   sinon.stub(airbrake, '_sendRequest');
@@ -24,4 +26,4 @@ MyError.prototype = Object.create(Error.prototype, {
 
   assert.ok(!airbrake._sendRequest.called);
   airbrake._sendRequest.restore();
-})();
+}());

--- a/test/fast/test-request-vars.js
+++ b/test/fast/test-request-vars.js
@@ -1,8 +1,6 @@
 var common = require('../common');
-var airbrake = require(common.dir.root).createClient()
+var airbrake = require(common.dir.root).createClient();
 var assert = require('assert');
-var xmlbuilder = require('xmlbuilder');
-var os = require('os');
 
 (function testSettingCustomExclusions() {
   var err = new Error();
@@ -12,7 +10,7 @@ var os = require('os');
 
   var cgiData = airbrake.environmentJSON(err);
   assert(!cgiData['err.domain']);
-})();
+}());
 
 (function testCgiDataFromProcessEnv() {
   var err = new Error();
@@ -28,7 +26,7 @@ var os = require('os');
   assert.ok(cgiData['process.memoryUsage'].rss);
   assert.equal(cgiData['os.loadavg'].length, 3);
   assert.equal(typeof cgiData['os.uptime'], 'number');
-})();
+}());
 
 (function testCustomErrorProperties() {
   var err = new Error();
@@ -36,63 +34,62 @@ var os = require('os');
 
   var cgiData = airbrake.environmentJSON(err);
   assert.equal(cgiData['err.myKey'], err.myKey);
-})();
+}());
 
-(function testWhitelistKeys(){
+(function testWhitelistKeys() {
   var err = new Error();
   err.myKey = 'some value';
 
-  airbrake.whiteListKeys.push("PWD");
+  airbrake.whiteListKeys.push('PWD');
   var cgiData = airbrake.environmentJSON(err);
-  assert.equal(typeof cgiData['PWD'], 'string');
-  assert.equal(cgiData['PATH'], '[FILTERED]');
+  assert.equal(typeof cgiData.PWD, 'string');
+  assert.equal(cgiData.PATH, '[FILTERED]');
   airbrake.whiteListKeys = [];
-})();
+}());
 
-(function testBlacklistKeys(){
+(function testBlacklistKeys() {
   var err = new Error();
   err.myKey = 'some value';
 
-  airbrake.blackListKeys.push("PWD");
+  airbrake.blackListKeys.push('PWD');
   var cgiData = airbrake.environmentJSON(err);
-  assert.equal(cgiData['PWD'], '[FILTERED]');
-  assert.equal(typeof cgiData['PATH'], 'string');
-  airbrake.blackListKeys = []
-})();
+  assert.equal(cgiData.PWD, '[FILTERED]');
+  assert.equal(typeof cgiData.PATH, 'string');
+  airbrake.blackListKeys = [];
+}());
 
 (function testSessionVars() {
   var err = new Error();
-  err.session = {foo: 'bar'};
+  err.session = { foo: 'bar' };
 
   var session = airbrake.sessionVars(err);
   assert.deepEqual(session, err.session);
-})();
+}());
 
 (function testParamsVars() {
   var err = new Error();
-  err.params = {foo: 'bar'};
+  err.params = { foo: 'bar' };
 
   var params = airbrake.paramsVars(err);
   assert.deepEqual(params, err.params);
-})();
+}());
 
 (function testCircularVars() {
-  var vars = {foo: 'bar', circular: {}};
+  var vars = { foo: 'bar', circular: {} };
   vars.circular.self = vars.circular;
   var err = new Error();
   err.params = vars;
 
   // test that no exception is thrown
   airbrake.notifyJSON(err);
-})();
+}());
 
 (function testAppendErrorXmlWithBadStack() {
-  var notice = xmlbuilder.create().begin('notice');
   var err = new Error('oh oh');
 
   err.stack += '\n    at Array.0 (native)';
   airbrake.notifyJSON(err);
-})();
+}());
 
 (function testEmptyErrorMessageDoesNotProduceInvalidXml() {
   // see: https://github.com/felixge/node-airbrake/issues/15
@@ -100,4 +97,4 @@ var os = require('os');
   var xml = airbrake.notifyJSON(err, true);
 
   assert.ok(!/<\/>/.test(xml));
-})();
+}());

--- a/test/run.js
+++ b/test/run.js
@@ -3,23 +3,23 @@ var far = require('far').create();
 
 far.add(__dirname);
 
-var specificTest = process.argv[2]
-if (undefined !== specificTest && 'all' !== specificTest) {
-  far.include(new RegExp('test-' + specificTest + '\.js$'));
+var specificTest = process.argv[2];
+if (typeof specificTest !== 'undefined' && specificTest !== 'all') {
+  far.include(new RegExp('test-' + specificTest + '.js$'));
 } else {
   far.include(/test-.*\.js$/);
 }
 
 
-var verbosity = process.argv[3]
-if (undefined !== verbosity) {
-  verbosity = Number(verbosity)
-  
-  if (1 !== verbosity && 2 !== verbosity) {
-    console.log('Please provide a verbosity value of 1 or 2')
-    process.exit(1)
+var verbosity = process.argv[3];
+if (typeof verbosity !== 'undefined') {
+  verbosity = Number(verbosity);
+
+  if (verbosity !== 1 && verbosity !== 2) {
+    console.log('Please provide a verbosity value of 1 or 2');
+    process.exit(1);
   }
 
-  far.verbose(verbosity)
-} 
+  far.verbose(verbosity);
+}
 far.execute();

--- a/test/slow/test-custom-request-options.js
+++ b/test/slow/test-custom-request-options.js
@@ -1,14 +1,14 @@
-var mockery = require('mockery'),
-  sinon = require('sinon'),
-  common = require('../common'),
-  assert = require('assert');
+var mockery = require('mockery');
+var sinon = require('sinon');
+var common = require('../common');
+var assert = require('assert');
 
 mockery.enable({
   warnOnReplace: false,
   warnOnUnregistered: false
 });
 
-var requestStub = sinon.stub()
+var requestStub = sinon.stub();
 
 mockery.registerMock('request', requestStub);
 
@@ -19,7 +19,7 @@ airbrake.requestOptions = {
   method: 'GET'
 };
 
-airbrake.notify(new Error('the error'), function() {});
+airbrake.notify(new Error('the error'), function () {});
 
 assert(requestStub.calledWith(
   sinon.match.has('myCustomOption', 'myCustomValue').and(
@@ -36,8 +36,8 @@ airbrake.requestOptions = {
 
 airbrake.trackDeployment({
   repo: Airbrake.PACKAGE.repository.url,
-  rev: '98103a8fa850d5eaf3666e419d8a0a93e535b1b2',
-}, function() {});
+  rev: '98103a8fa850d5eaf3666e419d8a0a93e535b1b2'
+}, function () {});
 
 assert(requestStub.calledWith(
   sinon.match.has('myCustomOption2', 'myCustomValue2').and(

--- a/test/slow/test-error-event.js
+++ b/test/slow/test-error-event.js
@@ -3,28 +3,28 @@ var airbrake = require(common.dir.root).createClient(null, common.key, 'producti
 var assert = require('assert');
 var http = require('http');
 
-var server = http.createServer(function(req, res) {
+var server = http.createServer(function (req, res) {
   res.writeHead(500);
   res.end('something went wrong');
 });
 
-
-server.listen(common.port, function() {
-  var err = new Error('test-notify');
+server.listen(common.port, function () {
+  var testNotifyError = new Error('test-notify');
   airbrake.serviceHost = 'localhost:' + common.port;
   airbrake.protocol = 'http';
 
-  var errorTimeout = setTimeout(function () {
-    errorTimeout = null
-    if (!errorProcessed) {
-      assert.ok(false, 'should have processed error before timeout of 5s')
-    }
-  }, 5000)
-
   var errorProcessed = false;
+
+  var errorTimeout = setTimeout(function () {
+    errorTimeout = null;
+    if (!errorProcessed) {
+      assert.ok(false, 'should have processed error before timeout of 5s');
+    }
+  }, 5000);
+
   airbrake.on('error', function (err) {
-    errorProcessed = true
-    if (null !== errorTimeout) {
+    errorProcessed = true;
+    if (errorTimeout !== null) {
       clearTimeout(errorTimeout);
     }
 
@@ -33,5 +33,5 @@ server.listen(common.port, function() {
     server.close();
   });
 
-  airbrake.notify(err);
+  airbrake.notify(testNotifyError);
 });

--- a/test/slow/test-handle-exceptions.js
+++ b/test/slow/test-handle-exceptions.js
@@ -1,6 +1,5 @@
 var common = require('../common');
 var airbrake = require(common.dir.root).createClient(null, common.key);
-var assert = require('assert');
 var sinon = require('sinon');
 
 var err = new Error('test-notify');
@@ -8,7 +7,7 @@ airbrake.handleExceptions();
 
 sinon.spy(airbrake, 'notify');
 
-process.on('exit', function() {
+process.on('exit', function () {
   var exitCode = (airbrake.notify.called)
     ? 0
     : 1;
@@ -17,4 +16,3 @@ process.on('exit', function() {
 });
 
 throw err;
-

--- a/test/slow/test-invalid-api-key.js
+++ b/test/slow/test-invalid-api-key.js
@@ -3,7 +3,7 @@ var airbrake = require(common.dir.root).createClient('1234', 'invalid', 'product
 var assert = require('assert');
 
 var myErr = new Error('test-notify');
-airbrake.notify(myErr, function(err) {
-  assert.ok(!!err, 'should receive an error object')
+airbrake.notify(myErr, function (err) {
+  assert.ok(!!err, 'should receive an error object');
   assert.ok(/401/i.test(err.message));
 });

--- a/test/slow/test-notify.js
+++ b/test/slow/test-notify.js
@@ -4,28 +4,29 @@ var sinon = require('sinon');
 var assert = require('assert');
 
 var err = new Error('Node.js just totally exploded on me');
-err.env = {protect: 'the environment!'};
-err.session = {iKnow: 'what you did last minute'};
+err.env = { protect: 'the environment!' };
+err.session = { iKnow: 'what you did last minute' };
 err.url = 'http://example.org/bad-url';
 
 var circular = {};
 circular.circular = circular;
 
-err.params = {some: 'params', circular: circular};
+err.params = { some: 'params', circular: circular };
 
-airbrake.on('vars', function(type, vars) {
+airbrake.on('vars', function (type, vars) {
+  /* eslint no-param-reassign: 0 */
   delete vars.SECRET;
 });
 
 var spy = sinon.spy();
 airbrake.notify(err, spy);
 
-process.on('exit', function() {
+process.on('exit', function () {
   assert.ok(spy.called);
 
-  var err = spy.args[0][0];
-  if (err) {
-    throw err;
+  var error = spy.args[0][0];
+  if (error) {
+    throw error;
   }
 
   var url = spy.args[0][1];

--- a/test/slow/test-throw-undefined.js
+++ b/test/slow/test-throw-undefined.js
@@ -1,13 +1,14 @@
+// Tests for throwing undefined, ignore rule.
+/* eslint no-throw-literal: 0 */
 var common = require('../common');
 var airbrake = require(common.dir.root).createClient(null, common.key);
-var assert = require('assert');
 var sinon = require('sinon');
 
 airbrake.handleExceptions();
 
 sinon.spy(airbrake, 'notify');
 
-process.on('exit', function() {
+process.on('exit', function () {
   var exitCode = (airbrake.notify.called)
     ? 0
     : 1;
@@ -16,4 +17,3 @@ process.on('exit', function() {
 });
 
 throw undefined;
-

--- a/test/slow/test-track-deployment.js
+++ b/test/slow/test-track-deployment.js
@@ -3,11 +3,10 @@ var Airbrake = require(common.dir.root);
 var airbrake = Airbrake.createClient(null, common.key);
 var sinon = require('sinon');
 var assert = require('assert');
+var execSync = require('sync-exec');
 
 var spy = sinon.spy();
-airbrake.trackDeployment({
-  rev: '98103a8fa850d5eaf3666e419d8a0a93e535b1b2'
-}, spy);
+airbrake.trackDeployment({}, spy);
 
 process.on('exit', function () {
   assert.strictEqual(spy.args[0][0], null);
@@ -18,6 +17,18 @@ process.on('exit', function () {
     'rev',
     'repo'
   ]);
-  assert.equal(spy.args[0][1].repo, 'git@github.com:airbrake/node-airbrake.git');
-  assert.equal(spy.args[0][1].rev, '98103a8fa850d5eaf3666e419d8a0a93e535b1b2');
+
+  var expectedRepo = execSync('git config --get remote.origin.url')
+    .stdout
+    .toString()
+    .slice(0, -1);
+
+  var expectedRev = execSync('git rev-parse HEAD')
+    .stdout
+    .toString()
+    .slice(0, -1);
+
+
+  assert.equal(spy.args[0][1].repo, expectedRepo);
+  assert.equal(spy.args[0][1].rev, expectedRev);
 });

--- a/test/slow/test-track-deployment.js
+++ b/test/slow/test-track-deployment.js
@@ -6,17 +6,17 @@ var assert = require('assert');
 
 var spy = sinon.spy();
 airbrake.trackDeployment({
-  rev: '98103a8fa850d5eaf3666e419d8a0a93e535b1b2',
+  rev: '98103a8fa850d5eaf3666e419d8a0a93e535b1b2'
 }, spy);
 
-process.on('exit', function() {
+process.on('exit', function () {
   assert.strictEqual(spy.args[0][0], null);
   assert.deepEqual(Object.keys(spy.args[0][1]), [
     'key',
     'env',
     'user',
     'rev',
-    'repo',
+    'repo'
   ]);
   assert.equal(spy.args[0][1].repo, 'git@github.com:airbrake/node-airbrake.git');
   assert.equal(spy.args[0][1].rev, '98103a8fa850d5eaf3666e419d8a0a93e535b1b2');


### PR DESCRIPTION
This PR makes two major changes:
- Adds ESLint to the project, using Airbnb's legacy rules (slightly modified, see `.eslintrc`, all changes relevant to the project). I've added it as a `posttest` step to `npm test`, so no CircleCI configuration modification required. Running `npm run lint` lints the codebase in development.
    * This change also caught some unused dependencies, and they have been removed as well.
- Updates deployment test to work on forks. The test was failing for me because `airbrake/node-airbrake.git` was hard-coded as the repo, but since I am working on a fork this broke.

I'm willing to squash this branch and field some feedback, but I think this is at a state where it's ready for review.