### PR TITLE
Update eslint-plugin-import to meet peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "eslint": "~2.8.0",
     "eslint-config-airbnb-base": "~1.0.3",
-    "eslint-plugin-import": "~1.5.0",
+    "eslint-plugin-import": "~1.6.1",
     "express": "~4.13.4",
     "far": "~0.0.4",
     "mockery": "~1.4.0",


### PR DESCRIPTION
This PR is a continuation of #93, where after being merged CircleCI builds were failing because of an unmet peer dependency. It seems that this does not break in npm3+, but npm2+ builds are failing because they explicitly need this dependency met. I've added it so there are no errors, no matter what version of Node the dependency is being met for.

@phumpal Let me know what you think.