### PR TITLE
Specify 'node-airbrake' as notifier/name instead of 'airbrake'

### DIFF
--- a/lib/airbrake.js
+++ b/lib/airbrake.js
@@ -264,7 +264,7 @@ Airbrake.prototype.environmentJSON = function (err) {
 Airbrake.prototype.contextJSON = function (err) {
   var context = {};
   context.notifier = {
-    name: Airbrake.PACKAGE.name,
+    name: 'node-airbrake',
     version: Airbrake.PACKAGE.version,
     url: Airbrake.PACKAGE.homepage
   };


### PR DESCRIPTION
General 'airbrake' is simply too obscure.