### PR TITLE
Use lodash individual modules instead of requiring the entire package

### DIFF
--- a/lib/airbrake.js
+++ b/lib/airbrake.js
@@ -5,7 +5,8 @@ var os = require('os');
 var EventEmitter = require('events').EventEmitter;
 var request = require('request');
 var stackTrace = require('stack-trace');
-var _ = require('lodash');
+var assign = require('lodash.assign');
+var merge = require('lodash.merge');
 var stringify = require('json-stringify-safe');
 var execSync = require('sync-exec');
 var url = require('url');
@@ -46,7 +47,7 @@ function Airbrake() {
   ];
 }
 
-_.assign(Airbrake.prototype, EventEmitter.prototype);
+assign(Airbrake.prototype, EventEmitter.prototype);
 
 Airbrake.PACKAGE = (function () {
   var json = fs.readFileSync(__dirname + '/../package.json', 'utf8');
@@ -130,7 +131,7 @@ Airbrake.prototype._sendRequest = function (err, cb) {
 
   var body = this.notifyJSON(err);
 
-  var options = _.merge({
+  var options = merge({
     method: 'POST',
     url: this.url('/api/v3/projects/' + this.projectId + '/notices?key=' + this.key),
     body: body,
@@ -326,7 +327,7 @@ Airbrake.prototype.trackDeployment = function (params, cb) {
     return command.stdout.toString().slice(0, -1);
   };
 
-  deploymentParams = _.merge({
+  deploymentParams = merge({
     key: this.key,
     env: this.env,
     user: process.env.USER,
@@ -336,7 +337,7 @@ Airbrake.prototype.trackDeployment = function (params, cb) {
 
   var body = this.deploymentPostData(deploymentParams);
 
-  var options = _.merge({
+  var options = merge({
     method: 'POST',
     url: this.url('/api/v4/projects/' + this.projectId + '/deploys?key=' + this.key),
     body: body,

--- a/lib/airbrake.js
+++ b/lib/airbrake.js
@@ -5,7 +5,6 @@ var os = require('os');
 var EventEmitter = require('events').EventEmitter;
 var request = require('request');
 var stackTrace = require('stack-trace');
-var assign = require('lodash.assign');
 var merge = require('lodash.merge');
 var stringify = require('json-stringify-safe');
 var execSync = require('sync-exec');
@@ -47,7 +46,7 @@ function Airbrake() {
   ];
 }
 
-assign(Airbrake.prototype, EventEmitter.prototype);
+merge(Airbrake.prototype, EventEmitter.prototype);
 
 Airbrake.PACKAGE = (function () {
   var json = fs.readFileSync(__dirname + '/../package.json', 'utf8');

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   },
   "dependencies": {
     "json-stringify-safe": "~5.0.0",
-    "lodash.assign": "^4.0.9",
     "lodash.merge": "^4.4.0",
     "request": "~2.69.0",
     "stack-trace": "~0.0.6",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   },
   "dependencies": {
     "json-stringify-safe": "~5.0.0",
-    "lodash": "^4.6.1",
+    "lodash.assign": "^4.0.9",
+    "lodash.merge": "^4.4.0",
     "request": "~2.69.0",
     "stack-trace": "~0.0.6",
     "sync-exec": "^0.6.2"

--- a/test/common.js
+++ b/test/common.js
@@ -3,7 +3,7 @@
 /* eslint import/no-unresolved: 0 */
 
 var path = require('path');
-var _ = require('lodash');
+var merge = require('lodash.merge');
 
 // An account on the free plan specifically for testing this module.
 exports.key = '96979331ec7e18bbe7ec1529da2ed083';
@@ -11,7 +11,7 @@ exports.projectId = '122374';
 
 // Use custom config if available instead
 try {
-  _.merge(exports, require('./config'));
+  merge(exports, require('./config'));
 } catch (e) { console.log(e); }
 
 exports.port = 8424;


### PR DESCRIPTION
I'm using node-airbrake with electron so size is an issue for me. lodash adds 1.3MB to my app so I'm hoping you can use the individual packages instead.