### PR TITLE
Give ability to filter exceptions from going to Airbrake the way it's done in the front-end airbrake-js library.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,12 +97,12 @@ The return value of the filter function determines whether or not the error noti
 
 An error notice must pass all provided filters to be submitted.
 
-In the following example all errors triggered by admins will be ignored:
+In the following example errors triggered with a message of 'this should not be posted to airbrake' will be ignored:
 
 ```js
 airbrake.addFilter(function(notice) {
-  if (notice.sessions.admin) {
-    // Ignore errors from admin sessions.
+  if (notice.errors[0].message === 'this should not be posted to airbrake') {
+    // Ignore errors with this messsage
     return null;
   }
   return notice;

--- a/README.md
+++ b/README.md
@@ -83,6 +83,42 @@ recommended):
 airbrake.handleExceptions(false);
 ```
 
+### Filtering errors
+
+There may be some errors thrown in your application that you're not interested in sending to Airbrake, such as errors thrown by 3rd-party libraries.
+
+The Airbrake notifier makes it simple to ignore this chaff while still processing legitimate errors. Add filters to the notifier by providing filter functions to `addFilter`.
+
+`addFilter` accepts the entire [error notice](https://airbrake.io/docs/#create-notice-v3) to be sent to Airbrake, and provides access to the `context`, `environment`, `params`, and `session` values submitted with the notice, as well as the single-element `errors` array with its `backtrace` element and associated backtrace lines.
+
+The return value of the filter function determines whether or not the error notice will be submitted.
+  * If null value is returned, the notice is ignored.
+  * Otherwise returned notice will be submitted.
+
+An error notice must pass all provided filters to be submitted.
+
+In the following example all errors triggered by admins will be ignored:
+
+```js
+airbrake.addFilter(function(notice) {
+  if (notice.sessions.admin) {
+    // Ignore errors from admin sessions.
+    return null;
+  }
+  return notice;
+});
+```
+
+Filters can be also used to modify notice payload, e.g. to set environment and application version:
+
+```js
+airbrake.addFilter(function(notice) {
+  notice.context.environment = 'production';
+  notice.context.version = '1.2.3';
+  return notice;
+});
+```
+
 ### Manual error delivery
 
 If you want more control over the delivery of your errors, you can also

--- a/lib/airbrake.js
+++ b/lib/airbrake.js
@@ -189,7 +189,9 @@ Airbrake.prototype.notify = function (err, cb) {
   var notice = this.notifyJSON(err);
 
   this.filters.forEach(function (filter) {
-    notice = filter(notice);
+    if (notice) {
+      notice = filter(notice);
+    }
   });
 
   if (exit || !notice) {

--- a/lib/airbrake.js
+++ b/lib/airbrake.js
@@ -143,7 +143,7 @@ Airbrake.prototype._sendRequest = function (body, cb) {
 
   request(options, function (requestErr, res, responseBody) {
     if (requestErr) {
-      return callback(err);
+      return callback(requestErr);
     }
 
     if (typeof responseBody === 'undefined') {
@@ -167,7 +167,7 @@ Airbrake.prototype._sendRequest = function (body, cb) {
   });
 };
 
-Airbrake.prototype.addFilter = function(filter) {
+Airbrake.prototype.addFilter = function (filter) {
   this.filters.push(filter);
 };
 
@@ -188,7 +188,7 @@ Airbrake.prototype.notify = function (err, cb) {
 
   var notice = this.notifyJSON(err);
 
-  this.filters.forEach(function(filter) {
+  this.filters.forEach(function (filter) {
     notice = filter(notice);
   });
 

--- a/lib/airbrake.js
+++ b/lib/airbrake.js
@@ -18,6 +18,7 @@ function Airbrake() {
   this.env = process.env.NODE_ENV || 'development';
   this.whiteListKeys = [];
   this.blackListKeys = [];
+  this.filters = [];
   this.projectRoot = process.cwd();
   this.appVersion = null;
   this.timeout = 30 * 1000;
@@ -125,10 +126,8 @@ Airbrake.prototype.log = function (str) {
   }
 };
 
-Airbrake.prototype._sendRequest = function (err, cb) {
+Airbrake.prototype._sendRequest = function (body, cb) {
   var callback = this._callback(cb);
-
-  var body = this.notifyJSON(err);
 
   var options = merge({
     method: 'POST',
@@ -168,6 +167,10 @@ Airbrake.prototype._sendRequest = function (err, cb) {
   });
 };
 
+Airbrake.prototype.addFilter = function(filter) {
+  this.filters.push(filter);
+};
+
 Airbrake.prototype.notify = function (err, cb) {
   var callback = this._callback(cb);
   var exit = false;
@@ -183,11 +186,17 @@ Airbrake.prototype.notify = function (err, cb) {
     }
   });
 
-  if (exit) {
+  var notice = this.notifyJSON(err);
+
+  this.filters.forEach(function(filter) {
+    notice = filter(notice);
+  });
+
+  if (exit || !notice) {
     return callback(null, null, false);
   }
 
-  return this._sendRequest(err, callback);
+  return this._sendRequest(stringify(notice), callback);
 };
 
 Airbrake.prototype._callback = function (cb) {
@@ -281,7 +290,7 @@ Airbrake.prototype.notifyJSON = function (err) {
   var trace = stackTrace.parse(err);
   var self = this;
 
-  return stringify({
+  return {
     errors: [
       {
         type: err.type || 'Error',
@@ -298,7 +307,7 @@ Airbrake.prototype.notifyJSON = function (err) {
     context: self.contextJSON(err),
     session: self.sessionVars(err),
     params: self.paramsVars(err)
-  });
+  };
 };
 
 Airbrake.prototype.sessionVars = function (err) {

--- a/test/fast/test-filter.js
+++ b/test/fast/test-filter.js
@@ -8,12 +8,23 @@ var Airbrake = require(common.dir.root);
   var airbrake = Airbrake.createClient(null, common.key, 'dev');
   sinon.stub(airbrake, '_sendRequest');
 
-  airbrake.addFilter(function (err) {
-    if (err.errors[0].message === 'this should not be posted to airbrake') {
+  airbrake.addFilter(function (notice) {
+    if (notice.errors[0].message === 'this should not be posted to airbrake') {
       return null;
     }
-    return err;
+
+    return notice;
   });
+
+  var spiedFunc = sinon.spy(function (notice) {
+    var modifiedNotice = notice;
+
+    modifiedNotice.context.version = '1.2.3';
+
+    return modifiedNotice;
+  });
+
+  airbrake.addFilter(spiedFunc);
 
   airbrake.notify(new Error('this should not be posted to airbrake'));
 
@@ -22,6 +33,11 @@ var Airbrake = require(common.dir.root);
   airbrake.notify(new Error('this should be posted to airbrake'));
 
   assert.ok(airbrake._sendRequest.called);
+
+  // Second filter should only have been called 1x
+  assert.ok(spiedFunc.calledOnce);
+
+  assert.equal(spiedFunc.returnValues[0].context.version, '1.2.3');
 
   airbrake._sendRequest.restore();
 }());

--- a/test/fast/test-filter.js
+++ b/test/fast/test-filter.js
@@ -1,0 +1,27 @@
+var common = require('../common');
+var assert = require('assert');
+var sinon = require('sinon');
+
+var Airbrake = require(common.dir.root);
+
+(function testAddingFilter() {
+  var airbrake = Airbrake.createClient(null, common.key, 'dev');
+  sinon.stub(airbrake, '_sendRequest');
+
+  airbrake.addFilter(function(err) {
+    if (err.errors[0].message === 'this should not be posted to airbrake') {
+      return null;
+    }
+    return err;
+  });
+
+  airbrake.notify(new Error('this should not be posted to airbrake'));
+
+  assert.ok(!airbrake._sendRequest.called);
+
+  airbrake.notify(new Error('this should be posted to airbrake'));
+
+  assert.ok(airbrake._sendRequest.called);
+
+  airbrake._sendRequest.restore();
+}());

--- a/test/fast/test-filter.js
+++ b/test/fast/test-filter.js
@@ -8,7 +8,7 @@ var Airbrake = require(common.dir.root);
   var airbrake = Airbrake.createClient(null, common.key, 'dev');
   sinon.stub(airbrake, '_sendRequest');
 
-  airbrake.addFilter(function(err) {
+  airbrake.addFilter(function (err) {
     if (err.errors[0].message === 'this should not be posted to airbrake') {
       return null;
     }


### PR DESCRIPTION
Was running into an issue where I needed to selectively fiter exceptions going to Airbrake. I see the undocumented ignoredExceptions functionality, however it is of limited use since its check is done using instanceOf and it's almost always an Error instance there. I modeled this fix off of the front-end airbrake-js library:

https://github.com/airbrake/airbrake-js#filtering-errors

