### PR TITLE
Delete the 'developmentEnvironments' option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Node Airbrake Changelog
 
 ### master
 
+* Removed the `developmentEnvironments` config option
+  ([#119](https://github.com/airbrake/node-airbrake/pull/112))
+
 ### [v1.1.0][v1.1.0] (July 30, 2016)
 
 * **IMPORTANT:** Added support for the Hapi framework

--- a/README.md
+++ b/README.md
@@ -300,10 +300,6 @@ The version of this app. Set to a semantic version number, or leave unset.
 
 The protocol to use.
 
-### airbrake.developmentEnvironments = []
-
-Do not post to Airbrake when running in these environments.
-
 ### airbrake.timeout = 30 * 1000
 
 The timeout after which to give up trying to notify Airbrake in ms.

--- a/lib/airbrake.js
+++ b/lib/airbrake.js
@@ -23,7 +23,6 @@ function Airbrake() {
   this.projectRoot = process.cwd();
   this.appVersion = null;
   this.timeout = 30 * 1000;
-  this.developmentEnvironments = ['development', 'test'];
   this.consoleLogError = false;
 
   this.proxy = null;
@@ -201,11 +200,6 @@ Airbrake.prototype.addFilter = function(filter) {
 Airbrake.prototype.notify = function(err, cb) {
   var callback = this._callback(cb);
   var exit = false;
-  // log errors instead of posting to airbrake if a dev enviroment
-  if (this.developmentEnvironments.indexOf(this.env) !== -1) {
-    this.log(err);
-    return callback(null, null, true);
-  }
 
   this.ignoredExceptions.forEach(function(exception) {
     if (err instanceof exception) {

--- a/test/fast/test-environment.js
+++ b/test/fast/test-environment.js
@@ -4,29 +4,6 @@ var sinon = require('sinon');
 
 var Airbrake = require(common.dir.root);
 
-(function testAddingKeyToDevelopmentEnvironments() {
-  var airbrake = Airbrake.createClient(null, common.key, 'dev');
-  airbrake.developmentEnvironments.push('dev');
-  sinon.stub(airbrake, '_sendRequest');
-
-  airbrake.notify(new Error('this should not be posted to airbrake'));
-
-  assert.ok(!airbrake._sendRequest.called);
-  airbrake._sendRequest.restore();
-}());
-
-(function testDevelopmentEnviroment() {
-  var airbrake = Airbrake.createClient(null, common.key, 'dev');
-  sinon.stub(airbrake, '_sendRequest');
-
-  // this should be posted to airbrake simply because we didn't add 'dev' to
-  // airbrake.developmentEnvironments.
-  airbrake.notify(new Error('this should be posted to airbrake'));
-
-  assert.ok(airbrake._sendRequest.called);
-  airbrake._sendRequest.restore();
-}());
-
 (function testProductionEnviroment() {
   var airbrake = Airbrake.createClient(null, common.key, 'production');
   sinon.stub(airbrake, '_sendRequest');


### PR DESCRIPTION
Fixes #118 (send non production environment bug to airbrake)

This functionality can be implemented with the `addFilter` API, if the
user needs it.