### PR TITLE
Require the key be passed into createClient()

### DIFF
--- a/lib/airbrake.js
+++ b/lib/airbrake.js
@@ -59,6 +59,11 @@ Airbrake.createClient = function(projectId, key, env) {
   instance.key = key;
   instance.env = env || instance.env;
   instance.projectId = projectId || instance.projectId;
+
+  if (!instance.key || !instance.projectId) {
+    throw new Error('Key or project ID missing during Airbrake.createClient()');
+  }
+
   return instance;
 };
 

--- a/test/fast/test-environment.js
+++ b/test/fast/test-environment.js
@@ -5,7 +5,7 @@ var sinon = require('sinon');
 var Airbrake = require(common.dir.root);
 
 (function testProductionEnviroment() {
-  var airbrake = Airbrake.createClient(null, common.key, 'production');
+  var airbrake = Airbrake.createClient(common.projectId, common.key, 'production');
   sinon.stub(airbrake, '_sendRequest');
 
   airbrake.notify(new Error('this should be posted to airbrake'));

--- a/test/fast/test-express-handler.js
+++ b/test/fast/test-express-handler.js
@@ -1,7 +1,7 @@
 var express = require('express');
 var app = express();
 var common = require('../common');
-var airbrake = require(common.dir.root).createClient(null, common.key);
+var airbrake = require(common.dir.root).createClient(common.projectId, common.key);
 var assert = require('assert');
 var sinon = require('sinon');
 var http = require('http');

--- a/test/fast/test-filter.js
+++ b/test/fast/test-filter.js
@@ -5,7 +5,7 @@ var sinon = require('sinon');
 var Airbrake = require(common.dir.root);
 
 (function testAddFilterFiresOnce() {
-  var airbrake = Airbrake.createClient(null, common.key, 'dev');
+  var airbrake = Airbrake.createClient(common.projectId, common.key, 'dev');
   sinon.stub(airbrake, '_sendRequest');
 
   var filter = sinon.spy(function(notice) { return notice; });
@@ -19,7 +19,7 @@ var Airbrake = require(common.dir.root);
 }());
 
 (function testAddFilterModifiesNotice() {
-  var airbrake = Airbrake.createClient(null, common.key, 'dev');
+  var airbrake = Airbrake.createClient(common.projectId, common.key, 'dev');
   sinon.stub(airbrake, '_sendRequest');
 
   var filter = sinon.spy(function(notice) {
@@ -38,7 +38,7 @@ var Airbrake = require(common.dir.root);
 }());
 
 (function testAddFilterIgnoresNotices() {
-  var airbrake = Airbrake.createClient(null, common.key, 'dev');
+  var airbrake = Airbrake.createClient(common.projectId, common.key, 'dev');
   sinon.stub(airbrake, '_sendRequest');
 
   airbrake.addFilter(function(_notice) { return null; });
@@ -47,7 +47,7 @@ var Airbrake = require(common.dir.root);
 }());
 
 (function testAddFilterStartsExecutionFromOldestFilter() {
-  var airbrake = Airbrake.createClient(null, common.key, 'dev');
+  var airbrake = Airbrake.createClient(common.projectId, common.key, 'dev');
   sinon.stub(airbrake, '_sendRequest');
 
   var nums = [];
@@ -69,7 +69,7 @@ var Airbrake = require(common.dir.root);
 }());
 
 (function testAddFilterStartsExecutionFromOldestFilterButStopsIfShouldIgnore() {
-  var airbrake = Airbrake.createClient(null, common.key, 'dev');
+  var airbrake = Airbrake.createClient(common.projectId, common.key, 'dev');
   sinon.stub(airbrake, '_sendRequest');
 
   var nums = [];

--- a/test/fast/test-handle-exceptions.js
+++ b/test/fast/test-handle-exceptions.js
@@ -1,5 +1,5 @@
 var common = require('../common');
-var airbrake = require(common.dir.root).createClient();
+var airbrake = require(common.dir.root).createClient(common.projectId, common.key);
 var assert = require('assert');
 var sinon = require('sinon');
 

--- a/test/fast/test-host.js
+++ b/test/fast/test-host.js
@@ -1,5 +1,5 @@
 var common = require('../common');
-var airbrake = require(common.dir.root).createClient();
+var airbrake = require(common.dir.root).createClient(common.projectId, common.key);
 var assert = require('assert');
 var os = require('os');
 

--- a/test/fast/test-ignored-exceptions.js
+++ b/test/fast/test-ignored-exceptions.js
@@ -17,7 +17,7 @@ MyError.prototype = Object.create(Error.prototype, {
 });
 
 (function testAddingExceptionToIgnoredExceptions() {
-  var airbrake = Airbrake.createClient(null, common.key, 'production');
+  var airbrake = Airbrake.createClient(common.projectId, common.key, 'production');
   airbrake.ignoredExceptions.push(MyError);
 
   sinon.stub(airbrake, '_sendRequest');

--- a/test/fast/test-initialization.js
+++ b/test/fast/test-initialization.js
@@ -1,0 +1,22 @@
+var common = require('../common');
+var assert = require('assert');
+var Airbrake = require(common.dir.root);
+
+(function testCreateClientWorks() {
+  assert.doesNotThrow(function() {
+    Airbrake.createClient(common.projectId, common.key);
+  });
+}());
+
+(function testMissingKeyThrows() {
+  assert.throws(function() {
+    Airbrake.createClient(common.projectId);
+  });
+}());
+
+(function testMissingProjectIdThrows() {
+  assert.throws(function() {
+    Airbrake.createClient(null, common.key);
+  });
+}());
+

--- a/test/fast/test-request-vars.js
+++ b/test/fast/test-request-vars.js
@@ -1,5 +1,5 @@
 var common = require('../common');
-var airbrake = require(common.dir.root).createClient();
+var airbrake = require(common.dir.root).createClient(common.projectId, common.key);
 var assert = require('assert');
 
 (function testSettingCustomExclusions() {

--- a/test/slow/test-custom-request-options.js
+++ b/test/slow/test-custom-request-options.js
@@ -13,7 +13,7 @@ var requestStub = sinon.stub();
 mockery.registerMock('request', requestStub);
 
 var Airbrake = require(common.dir.root);
-var airbrake = Airbrake.createClient(null, common.key, 'production');
+var airbrake = Airbrake.createClient(common.projectId, common.key, 'production');
 airbrake.requestOptions = {
   myCustomOption: 'myCustomValue',
   method: 'GET'

--- a/test/slow/test-error-event.js
+++ b/test/slow/test-error-event.js
@@ -1,5 +1,5 @@
 var common = require('../common');
-var airbrake = require(common.dir.root).createClient(null, common.key, 'production');
+var airbrake = require(common.dir.root).createClient(common.projectId, common.key, 'production');
 var assert = require('assert');
 var http = require('http');
 

--- a/test/slow/test-handle-exceptions.js
+++ b/test/slow/test-handle-exceptions.js
@@ -1,5 +1,5 @@
 var common = require('../common');
-var airbrake = require(common.dir.root).createClient(null, common.key);
+var airbrake = require(common.dir.root).createClient(common.projectId, common.key);
 var sinon = require('sinon');
 
 var err = new Error('test-notify');

--- a/test/slow/test-throw-undefined.js
+++ b/test/slow/test-throw-undefined.js
@@ -1,7 +1,7 @@
 // Tests for throwing undefined, ignore rule.
 /* eslint no-throw-literal: 0 */
 var common = require('../common');
-var airbrake = require(common.dir.root).createClient(null, common.key);
+var airbrake = require(common.dir.root).createClient(common.projectId, common.key);
 var sinon = require('sinon');
 
 airbrake.handleExceptions();

--- a/test/slow/test-track-deployment.js
+++ b/test/slow/test-track-deployment.js
@@ -1,6 +1,6 @@
 var common = require('../common');
 var Airbrake = require(common.dir.root);
-var airbrake = Airbrake.createClient(null, common.key);
+var airbrake = Airbrake.createClient(common.projectId, common.key);
 var sinon = require('sinon');
 var assert = require('assert');
 var execSync = require('sync-exec');


### PR DESCRIPTION
This change adds a check to ensure createClient() gets a key passed
into the createClient() call.

In previous versions of Airbrake the first argument was the key,
meaning that blindly upgrading the Airbrake version would result in
Airbrake throwing an error when reporting an error.  This change
results in this "failing fast", giving the developer feedback on
the incorrect usage.

Fixes #124