### PR TITLE
airbrake: drop 'sync-exec' dep in favour of 'child_process.execSync'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Node Airbrake Changelog
 
 ### master
 
+* **IMPORTANT:** dropped support for Node.js <= v0.12
 * Dropped `sync-exec` dependency in favour of native `child_process.execSync`
   ([#137](https://github.com/airbrake/node-airbrake/pull/137))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Node Airbrake Changelog
 
 ### master
 
+* Dropped `sync-exec` dependency in favour of native `child_process.execSync`
+  ([#137](https://github.com/airbrake/node-airbrake/pull/137))
+
 ### [v1.3.0][v1.3.0] (April 11, 2017)
 
 * Implemented payload truncation (notices over 64KB are not accepted by the

--- a/circle.yml
+++ b/circle.yml
@@ -4,22 +4,16 @@ dependencies:
     - ? |
         case $CIRCLE_NODE_INDEX in
           0)
-            nvm install 0.10.46
+            nvm install 4.8.2
             ;;
           1)
-            nvm install 0.11.16
-            ;;
-          2)
-            nvm install 0.12.15
-            ;;
-          3)
-            nvm install 4.4.7
-            ;;
-          4)
             nvm install 5.12.0
             ;;
-          5)
-            nvm install 6.3.1
+          2)
+            nvm install 6.10.2
+            ;;
+          3)
+            nvm install 7.9.0
             ;;
         esac
       :
@@ -30,22 +24,16 @@ test:
     - ? |
         case $CIRCLE_NODE_INDEX in
           0)
-            nvm use 0.10.46 && npm test
+            nvm use 4.8.2 && npm test
             ;;
           1)
-            nvm use 0.11.16 && npm test
-            ;;
-          2)
-            nvm use 0.12.15 && npm test
-            ;;
-          3)
-            nvm use 4.4.7 && npm test
-            ;;
-          4)
             nvm use 5.12.0 && npm test
             ;;
-          5)
-            nvm use 6.3.1 && npm test
+          2)
+            nvm use 6.10.2 && npm test
+            ;;
+          3)
+            nvm use 7.9.0 && npm test
             ;;
         esac
       :

--- a/lib/airbrake.js
+++ b/lib/airbrake.js
@@ -6,7 +6,7 @@ var EventEmitter = require('events').EventEmitter;
 var request = require('request');
 var stackTrace = require('stack-trace');
 var merge = require('lodash.merge');
-var execSync = require('sync-exec');
+var execSync = require('child_process').execSync;
 var url = require('url');
 
 var truncator = require('../lib/truncator');
@@ -369,16 +369,12 @@ Airbrake.prototype.trackDeployment = function(params, cb) {
     deploymentParams = {};
   }
 
-  var getCommandValue = function(command) {
-    return command.stdout.toString().slice(0, -1);
-  };
-
   deploymentParams = merge({
     key: this.key,
     env: this.env,
     user: process.env.USER,
-    rev: getCommandValue(execSync('git rev-parse HEAD')),
-    repo: getCommandValue(execSync('git config --get remote.origin.url'))
+    rev: execSync('git rev-parse HEAD').toString().trim(),
+    repo: execSync('git config --get remote.origin.url').toString().trim()
   }, deploymentParams);
 
   var body = this.deploymentPostData(deploymentParams);

--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "json-stringify-safe": "~5.0.0",
     "lodash.merge": "^4.4.0",
     "request": "^2.81.0",
-    "stack-trace": "~0.0.6",
-    "sync-exec": "^0.6.2"
+    "stack-trace": "~0.0.6"
   },
   "devDependencies": {
     "eslint": "~2.8.0",

--- a/test/slow/test-track-deployment.js
+++ b/test/slow/test-track-deployment.js
@@ -3,7 +3,7 @@ var Airbrake = require(common.dir.root);
 var airbrake = Airbrake.createClient(common.projectId, common.key);
 var sinon = require('sinon');
 var assert = require('assert');
-var execSync = require('sync-exec');
+var execSync = require('child_process').execSync;
 
 var spy = sinon.spy();
 airbrake.trackDeployment({}, spy);
@@ -18,17 +18,9 @@ process.on('exit', function() {
     'repo'
   ]);
 
-  var expectedRepo = execSync('git config --get remote.origin.url')
-    .stdout
-    .toString()
-    .slice(0, -1);
-
-  var expectedRev = execSync('git rev-parse HEAD')
-    .stdout
-    .toString()
-    .slice(0, -1);
-
-
+  var expectedRepo = execSync('git config --get remote.origin.url').toString().trim();
   assert.equal(spy.args[0][1].repo, expectedRepo);
+
+  var expectedRev = execSync('git rev-parse HEAD').toString().trim();
   assert.equal(spy.args[0][1].rev, expectedRev);
 });


### PR DESCRIPTION
Fixes #136 (Use of sync-exec@0.6.2 security risk)

With this change we lose compatibility with Node.js v0.12 (maintenance
ended in the end of 2016).