### PR TITLE
truncator: use 'JSON.stringify' instead of 'json-stringify-safe'

### DIFF
--- a/lib/airbrake.js
+++ b/lib/airbrake.js
@@ -42,9 +42,6 @@ function Airbrake() {
     'params',
     'component',
     'action',
-    'domain',
-    'domainEmitter',
-    'domainBound',
     'ua'
   ];
 }

--- a/lib/truncator.js
+++ b/lib/truncator.js
@@ -1,6 +1,3 @@
-var stringify = require('json-stringify-safe');
-
-
 function Truncator(level) {
   if (level === null || level === undefined || level < 0) {
     level = 0;
@@ -204,7 +201,7 @@ module.exports.jsonifyNotice = function jsonifyNotice(notice, maxLength) {
     notice.environment = truncateObj(notice.environment, level);
     notice.session = truncateObj(notice.session, level);
 
-    s = stringify(notice);
+    s = JSON.stringify(notice);
     if (s.length < maxLength) {
       return s;
     }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "posttest": "npm run lint"
   },
   "dependencies": {
-    "json-stringify-safe": "~5.0.0",
     "lodash.merge": "^4.4.0",
     "request": "^2.81.0",
     "stack-trace": "~0.0.6"


### PR DESCRIPTION
Possibly fixes #131 (JSON parsing problem with error messages involving
a pound sterling symbol (£))

We used to use this library when we didn't have payload truncation
support. Now, when payload truncation is in place, we truncate notices
before sending. The truncator resolves circular references, so we don't
need to depend on 'json-stringify-safe' anymore.