### PR TITLE
README: remove outdated information about environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,6 @@ airbrake.notify(err, function(err, url) {
 });
 ```
 
-By default only the errors from the production environment will get reported,
-so make sure to put `production` in your `NODE_ENV`.
-
 ### Severity
 
 [Severity](https://airbrake.io/docs/airbrake-faq/what-is-severity/) allows


### PR DESCRIPTION
Since https://github.com/airbrake/node-airbrake/pull/119 this is not
true anymore.