### PR TITLE
Add promise rejection handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,12 @@ Registers a `process.on('uncaughtException')` listener. When an uncaught
 exception occurs, the error is sent to Airbrake, and then re-thrown to
 kill the process.
 
+### airbrake.handlePromiseRejections()
+
+Registers a `process.on('unhandledRejection')` listener. When an uncaught
+exception occurs inside a promise, the error is sent to Airbrake, and then re-thrown to
+kill the process.
+
 ### airbrake.expressHandler(disableUncaughtException)
 
 A custom error handler that is used with Express. Integrate with Express

--- a/lib/airbrake.js
+++ b/lib/airbrake.js
@@ -157,6 +157,14 @@ Airbrake.prototype.handleExceptions = function(die) {
   });
 };
 
+Airbrake.prototype.handlePromiseRejections = function(die) {
+  var self = this;
+  var shouldDie = (typeof die === 'undefined') ? true : die;
+  process.on('unhandledRejection', function(reason) {
+    self._onError(reason, shouldDie);
+  });
+};
+
 Airbrake.prototype.log = function(str) {
   if (this.consoleLogError) {
     console.error(str);

--- a/test/test-handle-promise-rejections.js
+++ b/test/test-handle-promise-rejections.js
@@ -1,0 +1,82 @@
+var common = require('./common');
+var airbrake = require(common.dir.root).createClient(common.projectId, common.key);
+var assert = require('assert');
+var sinon = require('sinon');
+
+(function testNotifyForUnhandlePromiseRejections() {
+  sinon.stub(process, 'on');
+  sinon.stub(airbrake, 'notify');
+  sinon.stub(airbrake, 'log');
+
+  airbrake.handlePromiseRejections();
+
+  var event = process.on.args[0][0];
+  var handler = process.on.args[0][1];
+
+  assert.equal(event, 'unhandledRejection');
+
+  assert.ok(!airbrake.notify.called);
+
+  var err = new Error('i am uncaught!');
+  handler(err);
+
+  assert.ok(airbrake.notify.calledWith(err));
+  assert.ok(airbrake.log.calledWith('Airbrake: Uncaught exception, sending notification for:'));
+  assert.ok(airbrake.log.calledWith(err.stack));
+
+  airbrake.log.restore();
+
+  var notifyCb = airbrake.notify.args[0][1];
+
+  (function testNotifyOk() {
+    sinon.stub(airbrake, 'log');
+    sinon.stub(process, 'exit');
+
+    notifyCb();
+
+    assert.ok(/notified service/i.test(airbrake.log.args[0][0]));
+    assert.ok(process.exit.calledWith(1));
+
+    process.exit.restore();
+    airbrake.log.restore();
+  }());
+
+  (function testNotifyError() {
+    sinon.stub(airbrake, 'log');
+    sinon.stub(process, 'exit');
+    var notifyErr = new Error('notify error');
+
+    notifyCb(notifyErr);
+
+    assert.ok(/could not notify service/i.test(airbrake.log.args[0][0]));
+    assert.strictEqual(airbrake.log.args[1][0], notifyErr.stack);
+    assert.ok(process.exit.calledWith(1));
+
+    process.exit.restore();
+  }());
+
+  airbrake.log.restore();
+  airbrake.notify.restore();
+  process.on.restore();
+}());
+
+(function testDoNotKillProcessAfterUnhandlePromiseRejections() {
+  sinon.stub(process, 'on');
+  sinon.stub(airbrake, 'notify');
+  sinon.stub(airbrake, 'log');
+  sinon.stub(process, 'exit');
+
+  airbrake.handlePromiseRejections(false);
+
+  var handler = process.on.args[0][1];
+
+  var err = new Error('i am uncaught!');
+  handler(err);
+
+  assert.ok(!process.exit.calledWith(1));
+
+  process.exit.restore();
+  airbrake.log.restore();
+  airbrake.notify.restore();
+  process.on.restore();
+}());


### PR DESCRIPTION
At the moment, handleExceptions is only hooking to the process event `uncaughtException`.
Their is another important event to hook when trying to catch all the error events in the system, this is `unhandledRejection`.

From the docs:

> The 'unhandledRejection' event is emitted whenever a Promise is rejected and no error handler is attached to the promise within a turn of the event loop. When programming with Promises, exceptions are encapsulated as "rejected promises". Rejections can be caught and handled using promise.catch() and are propagated through a Promise chain. The 'unhandledRejection' event is useful for detecting and keeping track of promises that were rejected whose rejections have not yet been handled.

This change will allow the airbrake client to hook in this event and forward the errors.